### PR TITLE
Use `raw_input` in `confirm()` method

### DIFF
--- a/subsetter.py
+++ b/subsetter.py
@@ -226,7 +226,7 @@ class Db(object):
         print("\n".join(sorted(message)))
         if self.args.yes:
             return True
-        response = input("Proceed? (Y/n) ").strip().lower()
+        response = raw_input("Proceed? (Y/n) ").strip().lower()
         return (not response) or (response[0] == 'y')
 
 


### PR DESCRIPTION
Previously when I would run rdbms-subsetter, I'd get output along the lines of:

```
Create XXXX rows from source_database in schema.table
Create XXXX rows from source_database in schema.table
Create XXXX rows from source_database in schema.table
Create XXXX rows from source_database in schema.table
Proceed? (Y/n)
```

Pressing `Y`, or `y` would trigger an error, with the script complaint that Y wasn't defined. I had to end up using `"Y"` to proceed.

This tripped me up when using it on a project of my own, and it's a simple enough fix to add, so I'm proposing the use of [`raw_input`](https://docs.python.org/2.7/library/functions.html#raw_input) instead of [`input`](https://docs.python.org/2.7/library/functions.html#input), because it removes the need for you wrap `Y` in a string when confirming the creation of rows in tables.
